### PR TITLE
Ensure mobile pages use full width

### DIFF
--- a/all.html
+++ b/all.html
@@ -18,6 +18,7 @@
       font-family: 'Cairo', sans-serif;
       background-color: #f8fafc;
     }
+    .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
     body { font-family: 'Cairo', sans-serif; background-color: #f8fafc; }
+    .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;

--- a/men.html
+++ b/men.html
@@ -18,6 +18,7 @@
       font-family: 'Cairo', sans-serif;
       background-color: #f8fafc;
     }
+    .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;

--- a/unisex.html
+++ b/unisex.html
@@ -18,6 +18,7 @@
       font-family: 'Cairo', sans-serif;
       background-color: #f8fafc;
     }
+    .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;

--- a/women.html
+++ b/women.html
@@ -18,6 +18,7 @@
       font-family: 'Cairo', sans-serif;
       background-color: #f8fafc;
     }
+    .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;


### PR DESCRIPTION
## Summary
- Override Tailwind container width to span 100% so pages don't appear narrower than the viewport on mobile devices.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a623572ecc832aa45c4b22b0a5e0c3