### PR TITLE
Add Open Graph metadata for perfume site

### DIFF
--- a/all.html
+++ b/all.html
@@ -5,11 +5,34 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
+  function gtag(){dataLayer.push(arguments);} 
   gtag('js', new Date());
   gtag('config', 'G-N8G1EZJT5B');
 </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" href="image/logos.png">
+  <meta name="description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="keywords" content="مملكة العطور, Kingdom of Perfumes">
+  <meta property="og:title" content="مملكة العطور">
+  <meta property="og:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta property="og:image" content="https://perfumekingdom.store/image/logos.png">
+  <meta property="og:url" content="https://perfumekingdom.store/all.html">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ar">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="مملكة العطور">
+  <meta name="twitter:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="twitter:image" content="https://perfumekingdom.store/image/logos.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "مملكة العطور",
+    "alternateName": "Kingdom of Perfumes",
+    "url": "https://perfumekingdom.store/",
+    "logo": "https://perfumekingdom.store/image/logos.png"
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,29 @@
   <meta charset="UTF-8">
   <title>مملكة العطور</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" href="image/logos.png">
+  <meta name="description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="keywords" content="مملكة العطور, Kingdom of Perfumes">
+  <meta property="og:title" content="مملكة العطور">
+  <meta property="og:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta property="og:image" content="https://perfumekingdom.store/image/logos.png">
+  <meta property="og:url" content="https://perfumekingdom.store/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ar">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="مملكة العطور">
+  <meta name="twitter:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="twitter:image" content="https://perfumekingdom.store/image/logos.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "مملكة العطور",
+    "alternateName": "Kingdom of Perfumes",
+    "url": "https://perfumekingdom.store/",
+    "logo": "https://perfumekingdom.store/image/logos.png"
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>

--- a/men.html
+++ b/men.html
@@ -5,11 +5,34 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
+  function gtag(){dataLayer.push(arguments);} 
   gtag('js', new Date());
   gtag('config', 'G-N8G1EZJT5B');
 </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" href="image/logos.png">
+  <meta name="description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="keywords" content="مملكة العطور, Kingdom of Perfumes">
+  <meta property="og:title" content="مملكة العطور">
+  <meta property="og:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta property="og:image" content="https://perfumekingdom.store/image/logos.png">
+  <meta property="og:url" content="https://perfumekingdom.store/men.html">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ar">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="مملكة العطور">
+  <meta name="twitter:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="twitter:image" content="https://perfumekingdom.store/image/logos.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "مملكة العطور",
+    "alternateName": "Kingdom of Perfumes",
+    "url": "https://perfumekingdom.store/",
+    "logo": "https://perfumekingdom.store/image/logos.png"
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>

--- a/unisex.html
+++ b/unisex.html
@@ -5,11 +5,34 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
+  function gtag(){dataLayer.push(arguments);} 
   gtag('js', new Date());
   gtag('config', 'G-N8G1EZJT5B');
 </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" href="image/logos.png">
+  <meta name="description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="keywords" content="مملكة العطور, Kingdom of Perfumes">
+  <meta property="og:title" content="مملكة العطور">
+  <meta property="og:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta property="og:image" content="https://perfumekingdom.store/image/logos.png">
+  <meta property="og:url" content="https://perfumekingdom.store/unisex.html">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ar">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="مملكة العطور">
+  <meta name="twitter:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="twitter:image" content="https://perfumekingdom.store/image/logos.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "مملكة العطور",
+    "alternateName": "Kingdom of Perfumes",
+    "url": "https://perfumekingdom.store/",
+    "logo": "https://perfumekingdom.store/image/logos.png"
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>

--- a/women.html
+++ b/women.html
@@ -5,11 +5,34 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
+  function gtag(){dataLayer.push(arguments);} 
   gtag('js', new Date());
   gtag('config', 'G-N8G1EZJT5B');
 </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" href="image/logos.png">
+  <meta name="description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="keywords" content="مملكة العطور, Kingdom of Perfumes">
+  <meta property="og:title" content="مملكة العطور">
+  <meta property="og:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta property="og:image" content="https://perfumekingdom.store/image/logos.png">
+  <meta property="og:url" content="https://perfumekingdom.store/women.html">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ar">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="مملكة العطور">
+  <meta name="twitter:description" content="عطور رجالية ونسائية ومختلطة من مملكة العطور متجر موثوق يوفر أفضل العطور الأصلية.">
+  <meta name="twitter:image" content="https://perfumekingdom.store/image/logos.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "مملكة العطور",
+    "alternateName": "Kingdom of Perfumes",
+    "url": "https://perfumekingdom.store/",
+    "logo": "https://perfumekingdom.store/image/logos.png"
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>


### PR DESCRIPTION
## Summary
- add favicon and social meta tags pointing to `image/logos.png`
- include Schema.org organization data for better search display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d2dffcc832ab4e00eea163e3512